### PR TITLE
jenkins: add android steps

### DIFF
--- a/tools/buildsteps/android/configure-depends
+++ b/tools/buildsteps/android/configure-depends
@@ -1,0 +1,15 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=android
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+then
+  cd $WORKSPACE/tools/depends;./configure \
+    --with-tarballs=/opt/xbmc-tarballs \
+    --host=arm-linux-androideabi \
+    --with-sdk-path=$SDK_PATH \
+    --with-ndk=$NDK_PATH \
+    --with-sdk=android-$SDK_VERSION \
+    --with-toolchain=$TOOLCHAIN \
+    --prefix=$XBMC_DEPENDS_ROOT
+fi

--- a/tools/buildsteps/android/configure-xbmc
+++ b/tools/buildsteps/android/configure-xbmc
@@ -1,0 +1,5 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=android
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+make -C $WORKSPACE/tools/depends/target/xbmc

--- a/tools/buildsteps/android/make-depends
+++ b/tools/buildsteps/android/make-depends
@@ -1,0 +1,8 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=android
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+then
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS && git rev-list HEAD --max-count=1 -- . > $PATH_CHANGE_REV_FILENAME
+fi

--- a/tools/buildsteps/android/make-xbmc
+++ b/tools/buildsteps/android/make-xbmc
@@ -1,0 +1,5 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=android
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+cd $WORKSPACE;make -j$BUILDTHREADS

--- a/tools/buildsteps/android/package
+++ b/tools/buildsteps/android/package
@@ -1,0 +1,5 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=android
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+cd $WORKSPACE;make apk

--- a/tools/buildsteps/android/prepare-depends
+++ b/tools/buildsteps/android/prepare-depends
@@ -1,0 +1,13 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=android
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+#clean without depends for skipping depends build if possible
+cd $WORKSPACE;git clean -xfd -e "tools/depends"
+
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+then
+  #clean up the rest too
+  cd $WORKSPACE;git clean -xfd
+  cd $WORKSPACE/tools/depends/;./bootstrap
+fi

--- a/tools/buildsteps/android/prepare-xbmc
+++ b/tools/buildsteps/android/prepare-xbmc
@@ -1,0 +1,5 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=android
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+#nothing on android

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -30,6 +30,10 @@ case $XBMC_PLATFORM_DIR in
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
     ;;
+  android)
+    DEFAULT_SDK_VERSION=10
+    DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
+    DEFAULT_CONFIGURATION="Debug"
 esac
 
 if [ $SDK_VERSION == "Default" ]


### PR DESCRIPTION
After @Memphiz's work, it was dead-simple to get android building.

Note that a few values come from the builder: NDK_PATH, SDK_PATH, TOOLCHAIN.

Succcessfully builds.
