### PR TITLE
[rebrand] use dynamic app name for env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -472,6 +472,7 @@ lib/cpluff/stamp-h1
 /tools/EventClients/Makefile
 /tools/EventClients/Clients/OSXRemote/Makefile
 /tools/EventClients/Clients/OSXRemote/build/
+/tools/EventClients/Clients/OSXRemote/XBMCHelper.m
 /tools/EventClients/Clients/WiiRemote/WiiRemote
 
 # /tools/darwin/
@@ -482,6 +483,7 @@ lib/cpluff/stamp-h1
 /tools/darwin/packaging/osx/mkdmg-osx.sh
 /tools/darwin/packaging/migrate_to_kodi_ios.sh
 /tools/darwin/packaging/seatbeltunlock/mkdeb-seatbeltunlock.sh
+/tools/darwin/runtime/preflight
 
 # /tools/Linux/
 /tools/Linux/kodi.sh

--- a/configure.in
+++ b/configure.in
@@ -118,6 +118,7 @@ AC_DEFUN([XB_PUSH_FLAGS], [
 # version can be overridden by setting the following as ENV vars when running configure
 APP_NAME=${APP_NAME-$(${AWK} '/APP_NAME/ {print $2}' version.txt)}
 APP_NAME_LC=$(echo $APP_NAME | ${AWK} '{print tolower($0)}')
+APP_NAME_UC=$(echo $APP_NAME | ${AWK} '{print toupper($0)}')
 APP_VERSION_MAJOR=${APP_VERSION_MAJOR-$(${AWK} '/VERSION_MAJOR/ {print $2}' version.txt)}
 APP_VERSION_MINOR=${APP_VERSION_MINOR-$(${AWK} '/VERSION_MINOR/ {print $2}' version.txt)}
 APP_VERSION_TAG=${APP_VERSION_TAG-$(${AWK} '/VERSION_TAG/ {print $2}' version.txt)}
@@ -129,6 +130,7 @@ if test "$APP_NAME" != "" && test "$APP_VERSION_MAJOR" != "" && test "$APP_VERSI
   final_message="$final_message\n  ${APP_NAME} Version:\t${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}-${APP_VERSION_TAG}"
   AC_SUBST(APP_NAME)
   AC_SUBST(APP_NAME_LC)
+  AC_SUBST(APP_NAME_UC)
   AC_SUBST(APP_VERSION_MAJOR)
   AC_SUBST(APP_VERSION_MINOR)
   AC_SUBST(APP_VERSION_TAG)
@@ -2482,6 +2484,7 @@ OUTPUT_FILES="Makefile \
     tools/TexturePacker/Makefile \
     tools/EventClients/Makefile \
     tools/EventClients/Clients/OSXRemote/Makefile \
+    tools/EventClients/Clients/OSXRemote/XBMCHelper.m \
     xbmc/peripherals/bus/Makefile \
     xbmc/peripherals/devices/Makefile \
     xbmc/android/activity/Makefile \
@@ -2496,6 +2499,7 @@ OUTPUT_FILES="Makefile \
     tools/darwin/packaging/osx/mkdmg-osx.sh \
     tools/darwin/packaging/migrate_to_kodi_ios.sh \
     tools/darwin/packaging/seatbeltunlock/mkdeb-seatbeltunlock.sh \
+    tools/darwin/runtime/preflight \
     xbmc/osx/Info.plist \
     xbmc/osx/ios/XBMCIOS-Info.plist \
     xbmc/osx/atv2/XBMCATV2-Info.plist \

--- a/tools/EventClients/Clients/OSXRemote/XBMCHelper.m.in
+++ b/tools/EventClients/Clients/OSXRemote/XBMCHelper.m.in
@@ -268,7 +268,7 @@
   NSFileManager *fileManager = [NSFileManager defaultManager];
   if([fileManager fileExistsAtPath:mp_app_path]){
     if(mp_home_path && [mp_home_path length])
-      setenv("KODI_HOME", [mp_home_path UTF8String], 1);
+      setenv("@APP_NAME_UC@_HOME", [mp_home_path UTF8String], 1);
     //launch or activate xbmc
     if(![[NSWorkspace sharedWorkspace] launchApplication:mp_app_path])
       ELOG(@"Error launching %@", mp_app_path);

--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -104,8 +104,8 @@ print_crash_report()
     fi
     single_stacktrace "$PWD" 1
     # Find in plugins directories
-    if [ $KODI_HOME ]; then
-      BASEDIR=$KODI_HOME
+    if [ $@APP_NAME_UC@_HOME ]; then
+      BASEDIR=$@APP_NAME_UC@_HOME
     else
       BASEDIR="$LIBDIR/${bin_name}/"
     fi

--- a/tools/darwin/runtime/preflight.in
+++ b/tools/darwin/runtime/preflight.in
@@ -3,16 +3,16 @@
 die("No HOME set, cannot install defaults.\n")
     if !$ENV{'HOME'};
 
-die("No KODI_HOME set, cannot install defaults.\n")
-    if !$ENV{'KODI_HOME'};
+die("No @APP_NAME_UC@_HOME set, cannot install defaults.\n")
+    if !$ENV{'@APP_NAME_UC@_HOME'};
 
 sub get_home {
     return $ENV{'HOME'} if defined $ENV{'HOME'};
 }
 
 sub get_extras {
-    # KODI_HOME is assumed to be always setup
-    return $ENV{'KODI_HOME'}."/extras/" if get_os() eq "osx";
+    # @APP_NAME_UC@_HOME is assumed to be always setup
+    return $ENV{'@APP_NAME_UC@_HOME'}."/extras/" if get_os() eq "osx";
     return;
 }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -585,9 +585,12 @@ void CApplication::Preflight()
   // run any platform preflight scripts.
 #if defined(TARGET_DARWIN_OSX)
   CStdString install_path;
+  std::string appName = CCompileInfo::GetAppName();
+  std::string envAppHome = appName + "_HOME";
+  StringUtils::ToUpper(envAppHome);
 
   CUtil::GetHomePath(install_path);
-  setenv("KODI_HOME", install_path.c_str(), 0);
+  setenv(envAppHome.c_str(), install_path.c_str(), 0);
   install_path += "/tools/darwin/runtime/preflight";
   system(install_path.c_str());
 #endif
@@ -1078,14 +1081,16 @@ bool CApplication::InitDirectoriesLinux()
   std::string appName = CCompileInfo::GetAppName();
   std::string dotLowerAppName = "." + appName;
   StringUtils::ToLower(dotLowerAppName);
-  const char* envAppHome = "KODI_HOME";
-  const char* envAppBinHome = "KODI_BIN_HOME";
-  const char* envAppTemp = "KODI_TEMP";
-
+  std::string envAppHome = appName + "_HOME";
+  StringUtils::ToUpper(envAppHome);
+  std::string envAppBinHome = appName + "_BIN_HOME";
+  StringUtils::ToUpper(envAppBinHome);
+  std::string envAppTemp = appName + "_TEMP";
+  StringUtils::ToUpper(envAppTemp);
 
   CUtil::GetHomePath(appBinPath, envAppBinHome);
-  if (getenv(envAppHome))
-    appPath = getenv(envAppHome);
+  if (getenv(envAppHome.c_str()))
+    appPath = getenv(envAppHome.c_str());
   else
   {
     appPath = appBinPath;
@@ -1104,8 +1109,8 @@ bool CApplication::InitDirectoriesLinux()
   }
 
   /* Set some environment variables */
-  setenv(envAppBinHome, appBinPath.c_str(), 0);
-  setenv(envAppHome, appPath.c_str(), 0);
+  setenv(envAppBinHome.c_str(), appBinPath.c_str(), 0);
+  setenv(envAppHome.c_str(), appPath.c_str(), 0);
 
   if (m_bPlatformDirectories)
   {
@@ -1117,8 +1122,8 @@ bool CApplication::InitDirectoriesLinux()
 
     CStdString strTempPath = userHome;
     strTempPath = URIUtils::AddFileToFolder(strTempPath, dotLowerAppName + "/temp");
-    if (getenv(envAppTemp))
-      strTempPath = getenv(envAppTemp);
+    if (getenv(envAppTemp.c_str()))
+      strTempPath = getenv(envAppTemp.c_str());
     CSpecialProtocol::SetTempPath(strTempPath);
 
     URIUtils::AddSlashAtEnd(strTempPath);
@@ -1139,8 +1144,8 @@ bool CApplication::InitDirectoriesLinux()
 
     CStdString strTempPath = appPath;
     strTempPath = URIUtils::AddFileToFolder(strTempPath, "portable_data/temp");
-    if (getenv(envAppTemp))
-      strTempPath = getenv(envAppTemp);
+    if (getenv(envAppTemp.c_str()))
+      strTempPath = getenv(envAppTemp.c_str());
     CSpecialProtocol::SetTempPath(strTempPath);
     CreateUserDirs();
 
@@ -1171,7 +1176,11 @@ bool CApplication::InitDirectoriesOSX()
 
   std::string appPath;
   CUtil::GetHomePath(appPath);
-  setenv("KODI_HOME", appPath.c_str(), 0);
+  std::string appName = CCompileInfo::GetAppName();
+  std::string envAppHome = appName + "_HOME";
+  StringUtils::ToUpper(envAppHome);
+
+  setenv(envAppHome.c_str(), appPath.c_str(), 0);
 
 #if defined(TARGET_DARWIN_IOS)
   CStdString fontconfigPath;
@@ -1190,7 +1199,6 @@ bool CApplication::InitDirectoriesOSX()
     CSpecialProtocol::SetXBMCBinPath(appPath);
     CSpecialProtocol::SetXBMCPath(appPath);
     #if defined(TARGET_DARWIN_IOS)
-      std::string appName = CCompileInfo::GetAppName();
       CSpecialProtocol::SetHomePath(userHome + "/" + CDarwinUtils::GetAppRootFolder() + "/" + appName);
       CSpecialProtocol::SetMasterProfilePath(userHome + "/" + CDarwinUtils::GetAppRootFolder() + "/" + appName + "/userdata");
     #else
@@ -1251,7 +1259,13 @@ bool CApplication::InitDirectoriesWin32()
   CStdString xbmcPath;
 
   CUtil::GetHomePath(xbmcPath);
-  CEnvironment::setenv("KODI_HOME", xbmcPath);
+  std::string appName = CCompileInfo::GetAppName();
+  std::string envAppHome = appName + "_HOME";
+  StringUtils::ToUpper(envAppHome);
+  std::string envAppProfile = appName + "_PROFILE_USERDATA";
+  StringUtils::ToUpper(envAppProfile);
+
+  CEnvironment::setenv(envAppHome.c_str(), xbmcPath);
   CSpecialProtocol::SetXBMCBinPath(xbmcPath);
   CSpecialProtocol::SetXBMCPath(xbmcPath);
 
@@ -1262,7 +1276,7 @@ bool CApplication::InitDirectoriesWin32()
   CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(strWin32UserFolder, "userdata"));
   CSpecialProtocol::SetTempPath(URIUtils::AddFileToFolder(strWin32UserFolder,"cache"));
 
-  CEnvironment::setenv("KODI_PROFILE_USERDATA", CSpecialProtocol::TranslatePath("special://masterprofile/"));
+  CEnvironment::setenv(envAppProfile.c_str(), CSpecialProtocol::TranslatePath("special://masterprofile/"));
 
   CreateUserDirs();
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -406,7 +406,12 @@ void CUtil::RunShortcut(const char* szShortcutPath)
 void CUtil::GetHomePath(std::string& strPath, const std::string& strTarget)
 {
   if (strTarget.empty())
-    strPath = CEnvironment::getenv("KODI_HOME");
+  {
+    std::string appName = CCompileInfo::GetAppName();
+    std::string envAppHome = appName + "_HOME";
+    StringUtils::ToUpper(envAppHome);
+    strPath = CEnvironment::getenv(envAppHome.c_str());
+  }
   else
     strPath = CEnvironment::getenv(strTarget);
 

--- a/xbmc/android/activity/XBMCApp.cpp
+++ b/xbmc/android/activity/XBMCApp.cpp
@@ -614,18 +614,25 @@ void CXBMCApp::SetupEnv()
   std::string appName = CCompileInfo::GetAppName();
   StringUtils::ToLower(appName);
   std::string className = "org.xbmc." + appName;
+  std::string envAppHome = appName + "_HOME";
+  StringUtils::ToUpper(envAppHome);
+  std::string envAppBinHome = appName + "_BIN_HOME";
+  StringUtils::ToUpper(envAppBinHome);
+  std::string envAppTemp = appName + "_TEMP";
+  StringUtils::ToUpper(envAppTemp);
+
 
   std::string xbmcHome = CJNISystem::getProperty("xbmc.home", "");
   if (xbmcHome.empty())
   {
     std::string cacheDir = getCacheDir().getAbsolutePath();
-    setenv("KODI_BIN_HOME", (cacheDir + "/apk/assets").c_str(), 0);
-    setenv("KODI_HOME", (cacheDir + "/apk/assets").c_str(), 0);
+    setenv(envAppBinHome.c_str(), (cacheDir + "/apk/assets").c_str(), 0);
+    setenv(envAppHome.c_str(), (cacheDir + "/apk/assets").c_str(), 0);
   }
   else
   {
-    setenv("KODI_BIN_HOME", (xbmcHome + "/assets").c_str(), 0);
-    setenv("KODI_HOME", (xbmcHome + "/assets").c_str(), 0);
+    setenv(envAppBinHome.c_str(), (xbmcHome + "/assets").c_str(), 0);
+    setenv(envAppHome.c_str(), (xbmcHome + "/assets").c_str(), 0);
   }
 
   std::string externalDir = CJNISystem::getProperty("xbmc.data", "");
@@ -642,7 +649,7 @@ void CXBMCApp::SetupEnv()
   if (!externalDir.empty())
     setenv("HOME", externalDir.c_str(), 0);
   else
-    setenv("HOME", getenv("KODI_TEMP"), 0);
+    setenv("HOME", getenv(envAppTemp.c_str()), 0);
 }
 
 std::string CXBMCApp::GetFilenameFromIntent(const CJNIIntent &intent)

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -54,8 +54,11 @@ bool CXRandR::Query(bool force, bool ignoreoff)
       return m_outputs.size() > 0;
 
   m_bInit = true;
+  std::string appName = CCompileInfo::GetAppName();
+  std::string envAppBinHome = appName + "_BIN_HOME";
+  StringUtils::ToUpper(envAppBinHome);
 
-  if (getenv("KODI_BIN_HOME") == NULL)
+  if (getenv(envAppBinHome.c_str()) == NULL)
     return false;
 
   m_outputs.clear();
@@ -75,9 +78,12 @@ bool CXRandR::Query(bool force, int screennum, bool ignoreoff)
   std::string cmd;
   std::string appname = CCompileInfo::GetAppName();
   StringUtils::ToLower(appname);
-  if (getenv("KODI_BIN_HOME"))
+  std::string envAppBinHome = appname + "_BIN_HOME";
+  StringUtils::ToUpper(envAppBinHome);
+
+  if (getenv(envAppBinHome.c_str()))
   {
-    cmd  = getenv("KODI_BIN_HOME");
+    cmd  = getenv(envAppBinHome.c_str());
     cmd += "/" + appname + "-xrandr";
     cmd = StringUtils::Format("%s -q --screen %d", cmd.c_str(), screennum);
   }
@@ -162,10 +168,12 @@ bool CXRandR::TurnOffOutput(CStdString name)
   std::string cmd;
   std::string appname = CCompileInfo::GetAppName();
   StringUtils::ToLower(appname);
+  std::string envAppBinHome = appname + "_BIN_HOME";
+  StringUtils::ToUpper(envAppBinHome);
 
-  if (getenv("KODI_BIN_HOME"))
+  if (getenv(envAppBinHome.c_str()))
   {
-    cmd  = getenv("KODI_BIN_HOME");
+    cmd  = getenv(envAppBinHome.c_str());
     cmd += "/" + appname + "-xrandr";
     cmd = StringUtils::Format("%s --screen %d --output %s --off", cmd.c_str(), output->screen, name.c_str());
   }
@@ -326,11 +334,13 @@ bool CXRandR::SetMode(XOutput output, XMode mode)
   m_currentMode = modeFound.id;
   std::string appname = CCompileInfo::GetAppName();
   StringUtils::ToLower(appname);
+  std::string envAppBinHome = appname + "_BIN_HOME";
+  StringUtils::ToUpper(envAppBinHome);
   char cmd[255];
 
-  if (getenv("KODI_BIN_HOME"))
+  if (getenv(envAppBinHome.c_str()))
     snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --screen %d --output %s --mode %s", 
-               getenv("KODI_BIN_HOME"),appname.c_str(),
+               getenv(envAppBinHome.c_str()),appname.c_str(),
                outputFound.screen, outputFound.name.c_str(), modeFound.id.c_str());
   else
     return false;
@@ -420,10 +430,12 @@ void CXRandR::LoadCustomModeLinesToAllOutputs(void)
     StringUtils::Trim(strModeLine);
     std::string appname = CCompileInfo::GetAppName();
     StringUtils::ToLower(appname);
+    std::string envAppBinHome = appname + "_BIN_HOME";
+    StringUtils::ToUpper(envAppBinHome);
 
-    if (getenv("KODI_BIN_HOME"))
+    if (getenv(envAppBinHome.c_str()))
     {
-      snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --newmode \"%s\" %s > /dev/null 2>&1", getenv("KODI_BIN_HOME"),
+      snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --newmode \"%s\" %s > /dev/null 2>&1", getenv(envAppBinHome.c_str()),
                appname.c_str(), name.c_str(), strModeLine.c_str());
       if (system(cmd) != 0)
         CLog::Log(LOGERROR, "Unable to create modeline \"%s\"", name.c_str());
@@ -431,9 +443,9 @@ void CXRandR::LoadCustomModeLinesToAllOutputs(void)
 
     for (unsigned int i = 0; i < m_outputs.size(); i++)
     {
-      if (getenv("KODI_BIN_HOME"))
+      if (getenv(envAppBinHome.c_str()))
       {
-        snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --addmode %s \"%s\"  > /dev/null 2>&1", getenv("KODI_BIN_HOME"),
+        snprintf(cmd, sizeof(cmd), "%s/%s-xrandr --addmode %s \"%s\"  > /dev/null 2>&1", getenv(envAppBinHome.c_str()),
                  appname.c_str(), m_outputs[i].name.c_str(), name.c_str());
         if (system(cmd) != 0)
           CLog::Log(LOGERROR, "Unable to add modeline \"%s\"", name.c_str());


### PR DESCRIPTION
Fair warning, this is only tested on linux and not very thoroughly, up to you if you want to include it.