### PR TITLE
Derive the app group ID from the main bundle ID

### DIFF
--- a/xbmc/platform/darwin/tvos/Kodi.entitlements
+++ b/xbmc/platform/darwin/tvos/Kodi.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.org.xbmc.shared</string>
+		<string>group.org.xbmc.kodi-tvos.shared</string>
 	</array>
 </dict>
 </plist>

--- a/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
+++ b/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
@@ -22,6 +22,7 @@
 #import "system.h"
 
 #import "TVOSTopShelf.h"
+#import "tvosShared.h"
 
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
@@ -65,12 +66,13 @@ CTVOSTopShelf &CTVOSTopShelf::GetInstance()
 void CTVOSTopShelf::SetTopShelfItems(CFileItemList& movies, CFileItemList& tv)
 {
   CVideoThumbLoader loader;
+  NSString *sharedID = [tvosShared getSharedID];
   NSMutableArray * movieArray = [[NSMutableArray alloc] init];
   NSMutableArray * tvArray = [[NSMutableArray alloc] init];
-  NSUserDefaults *shared = [[NSUserDefaults alloc] initWithSuiteName:@"group.org.xbmc.shared"];
+  NSUserDefaults *shared = [[NSUserDefaults alloc] initWithSuiteName:sharedID];
   
   NSFileManager* fileManager = [NSFileManager defaultManager];
-  NSURL* storeUrl = [fileManager containerURLForSecurityApplicationGroupIdentifier:@"group.org.xbmc.shared"];
+  NSURL* storeUrl = [fileManager containerURLForSecurityApplicationGroupIdentifier:sharedID];
   storeUrl = [storeUrl URLByAppendingPathComponent:@"Library" isDirectory:TRUE];
   storeUrl = [storeUrl URLByAppendingPathComponent:@"Caches" isDirectory:TRUE];
   storeUrl = [storeUrl URLByAppendingPathComponent:@"RA" isDirectory:TRUE];

--- a/xbmc/platform/darwin/tvos/TopShelf/ServiceProvider.m
+++ b/xbmc/platform/darwin/tvos/TopShelf/ServiceProvider.m
@@ -19,6 +19,7 @@
  */
 
 #import "ServiceProvider.h"
+#import "../tvosShared.h"
 
 @interface ServiceProvider ()
 
@@ -44,13 +45,14 @@
 
 - (NSArray *)topShelfItems
 {
-    NSMutableArray *topShelfItems = [[NSMutableArray alloc] init];;
-    NSUserDefaults *shared = [[NSUserDefaults alloc] initWithSuiteName:@"group.org.xbmc.shared"];
+  NSString *sharedID = [tvosShared getSharedID];
+    NSMutableArray *topShelfItems = [[NSMutableArray alloc] init];
+    NSUserDefaults *shared = [[NSUserDefaults alloc] initWithSuiteName:sharedID];
   
     TVContentIdentifier *wrapperIdentifier = [[TVContentIdentifier alloc] initWithIdentifier:@"shelf-wrapper" container:nil];
   
     NSFileManager* fileManager = [NSFileManager defaultManager];
-    NSURL* storeUrl = [fileManager containerURLForSecurityApplicationGroupIdentifier:@"group.org.xbmc.shared"];
+    NSURL* storeUrl = [fileManager containerURLForSecurityApplicationGroupIdentifier:sharedID];
     storeUrl = [storeUrl URLByAppendingPathComponent:@"Library" isDirectory:TRUE];
     storeUrl = [storeUrl URLByAppendingPathComponent:@"Caches" isDirectory:TRUE];
     storeUrl = [storeUrl URLByAppendingPathComponent:@"RA" isDirectory:TRUE];

--- a/xbmc/platform/darwin/tvos/TopShelf/TopShelf.entitlements
+++ b/xbmc/platform/darwin/tvos/TopShelf/TopShelf.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.org.xbmc.shared</string>
+		<string>group.org.xbmc.kodi-tvos.shared</string>
 	</array>
 </dict>
 </plist>

--- a/xbmc/platform/darwin/tvos/tvosShared.h
+++ b/xbmc/platform/darwin/tvos/tvosShared.h
@@ -1,0 +1,25 @@
+/*
+ *      Copyright (C) 2016 Daniel Radtke
+ *      http://github.com/dantheman827/
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface tvosShared : NSObject
++ (NSString *)getSharedID;
+@end

--- a/xbmc/platform/darwin/tvos/tvosShared.m
+++ b/xbmc/platform/darwin/tvos/tvosShared.m
@@ -1,0 +1,40 @@
+/*
+ *      Copyright (C) 2016 Daniel Radtke
+ *      http://github.com/dantheman827/
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface tvosShared : NSObject
++ (NSString *)getSharedID;
+@end
+
+@implementation tvosShared : NSObject
++ (NSString *)getSharedID {
+  NSString *bundleID;
+  NSBundle *bundle = [NSBundle mainBundle];
+  if ([[bundle.bundleURL pathExtension] isEqualToString:@"appex"]) { // We're in a extension
+    // Peel off two directory levels - Kodi.app/PlugIns/MY_APP_EXTENSION.appex
+    bundle = [NSBundle bundleWithURL:[[bundle.bundleURL URLByDeletingLastPathComponent] URLByDeletingLastPathComponent]];
+    bundleID = bundle.bundleIdentifier;
+  } else {
+    bundleID = [NSBundle mainBundle].bundleIdentifier;
+  }
+  return [[@"group." stringByAppendingString:bundleID] stringByAppendingString:@".shared"];
+}
+@end


### PR DESCRIPTION
@Memphiz This enables my iOS App Signer to properly sign the app with a working top shelf.