### PR TITLE
fixup! [UWP] - don't use sparkle updater on UWP platform

### DIFF
--- a/xbmc/utils/UpdateHandler.cpp
+++ b/xbmc/utils/UpdateHandler.cpp
@@ -26,10 +26,11 @@
 
 #if defined(TARGET_DARWIN_OSX)
 #include "platform/darwin/osx/UpdaterOsx.h"
-#elif defined(TARGET_WINDOWS) && !defined(TARGET_WIN10)
-// TARGET_WIN10 - is UWP which supdated via app store - so don't use our
+#elif defined(TARGET_WINDOWS_DESKTOP)
 // sparkle updater in that case
 #include "platform/win32/UpdaterWindows.h"
+#include <regex>
+#include "Util.h"
 #endif
 
 IUpdater *CUpdateHandler::impl = NULL;
@@ -41,10 +42,11 @@ CUpdateHandler::CUpdateHandler()
   {
 #if defined(TARGET_DARWIN_OSX)
     impl = new CUpdaterOsx();
-#elif defined(TARGET_WINDOWS) && !defined(TARGET_WIN10)
-    // TARGET_WIN10 - is UWP which supdated via app store - so don't use our
+#elif defined(TARGET_WINDOWS_DESKTOP)
     // sparkle updater in that case
-    impl = new CUpdaterWindows();
+    std::regex windowsApps(R"_([\/\\]WindowsApps[\/\\])_");
+    if (!std::regex_search(CUtil::ResolveExecutablePath(), windowsApps))
+      impl = new CUpdaterWindows();
 #endif
   }
 }


### PR DESCRIPTION
correct preprocessor defines and add a runtime check for windows desktop bridge app store